### PR TITLE
version 0.3: dependencies upgrades and minor cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,11 @@ To install the archetype in your local repo:
 
 Now, you can use the archetype in a new project typing:
 
-    mvn archetype:generate -DarchetypeGroupId=com.sebarmeli -DarchetypeArtifactId=selenium2-java-quickstart-archetype -DarchetypeVersion=0.2 -DgroupId=<mygroupId> -DartifactId=<myartifactId>
+    mvn archetype:generate -DarchetypeGroupId=com.sebarmeli -DarchetypeArtifactId=selenium2-java-quickstart-archetype -DarchetypeVersion=0.3 -DgroupId=<mygroupId> -DartifactId=<myartifactId>
     						 
 where *mygroupId* : group id of the project you are creating; *myartifactId* : artifact id of the project you are creating
 
-It uses Java bindings for Selenium version 2.12.0, OperaDriver version 0.7.3 and TestNG version 6.3.
-
+It uses Java bindings for Selenium version 2.47.2 and TestNG version 6.9.6. OperaDriver 1.5, Appium's ios-driver 3.2.0 and Selendroid 0.16.0 are also included for convenience.
 
 Project Structure
 -----------------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -10,12 +10,11 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.sebarmeli</groupId>
 	<artifactId>selenium2-java-quickstart-archetype</artifactId>
-	<version>0.2</version>
+	<version>0.3</version>
 	<name>Selenium2 Java QuickStart Archetype</name>
-	<packaging>maven-archetype</packaging>
 	<description>Generates a QuickStart project with Selenium 2 and TestNG</description>
 	<properties>
-		<archetype.version>2.1</archetype.version>
+		<archetype.version>2.4</archetype.version>
 	</properties>
 	<licenses>
 		<license>

--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -7,29 +7,29 @@
 	the specific language governing permissions and limitations under the License. -->
 <archetype-descriptor name="selenium2-java-quickstart-archetype">
 	<fileSets>
-		<fileSet filtered="true" encoding="UTF-8">
-			<directory></directory>
+		<fileSet filtered="true" packaged="true" encoding="UTF-8">
+			<directory>src/main/java</directory>
 			<includes>
-				<include>*.xml</include>
+				<include>**/*</include>
 			</includes>
 		</fileSet>
 		<fileSet filtered="true" packaged="true" encoding="UTF-8">
-			<directory>src/main/java</directory>
-		</fileSet>
-		<fileSet filtered="true" packaged="true" encoding="UTF-8">
 			<directory>src/test/java</directory>
+            <includes>
+                <include>**/*</include>
+            </includes>
 		</fileSet>
 		<fileSet filtered="true" encoding="UTF-8">
 			<directory>src/main/resources</directory>
-		</fileSet>
-		<fileSet> 
-			<directory>src/main/resources/drivers/chrome/</directory>
-		</fileSet>
-		<fileSet>
-			<directory>src/main/resources/grid2</directory>
+            <includes>
+                <include>**/*</include>
+            </includes>
 		</fileSet>
 		<fileSet filtered="true" encoding="UTF-8">
 			<directory>src/test/resources</directory>
+            <includes>
+                <include>**/*</include>
+            </includes>
 		</fileSet>
 	</fileSets>
 </archetype-descriptor>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -1,30 +1,45 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>${groupId}</groupId>
-  <artifactId>${artifactId}</artifactId>
-  <version>${version}</version>
-  <packaging>jar</packaging>
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>${groupId}</groupId>
+	<artifactId>${artifactId}</artifactId>
+	<version>${version}</version>
+	<packaging>jar</packaging>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.testng</groupId>
 			<artifactId>testng</artifactId>
-			<version>6.3</version>
+			<version>6.9.6</version>
 		</dependency>
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>2.33.0</version>
+			<version>2.47.2</version>
+		</dependency>
+		<dependency>
+			<groupId>io.selendroid</groupId>
+			<version>0.16.0</version>
+			<artifactId>selendroid-standalone</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.selendroid</groupId>
+			<version>0.16.0</version>
+			<artifactId>selendroid-client</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.appium</groupId>
+			<artifactId>java-client</artifactId>
+			<version>3.2.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.opera</groupId>
 			<artifactId>operadriver</artifactId>
-			<version>0.7.3</version>
+			<version>1.5</version>
 		</dependency>
 	</dependencies>
 	<build>
-		<resources> 
+		<resources>
 			<resource>
 				<directory>src/main/resources</directory>
 				<filtering>true</filtering>
@@ -34,11 +49,11 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
-				<version>2.3</version>
+				<version>2.7</version>
 				<configuration>
 					<encoding>UTF-8</encoding>
 				</configuration>
-			</plugin> 
+			</plugin>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
@@ -49,10 +64,10 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
+				<version>3.3</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/src/main/resources/archetype-resources/src/main/java/webdriver/WebDriverFactory.java
+++ b/src/main/resources/archetype-resources/src/main/java/webdriver/WebDriverFactory.java
@@ -8,23 +8,19 @@ import java.net.URL;
 
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.android.AndroidDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxProfile;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 import org.openqa.selenium.ie.InternetExplorerDriver;
-import org.openqa.selenium.safari.SafariDriver;
-import org.openqa.selenium.iphone.IPhoneDriver;
 import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.safari.SafariDriver;
 
 import com.opera.core.systems.OperaDriver;
 import ${groupId}.util.Browser;
 import ${groupId}.webdriver.AuthenticatedHtmlUnitDriver;
-
-import ${groupId}.util.Browser;
 
 /*
  * Factory to instantiate a WebDriver object. It returns an instance of the driver (local invocation) or an instance of RemoteWebDriver
@@ -103,7 +99,7 @@ public class WebDriverFactory {
 					InternetExplorerDriver.INTRODUCE_FLAKINESS_BY_IGNORING_SECURITY_DOMAINS,
 					true);
 		} else if (OPERA.equals(browserName)) {
-			capability = DesiredCapabilities.opera();
+			capability = DesiredCapabilities.operaBlink();
         } else if (SAFARI.equals(browserName)) {
             capability = DesiredCapabilities.safari();
 		} else if (ANDROID.equals(browserName)) {
@@ -180,17 +176,13 @@ public class WebDriverFactory {
             isSupportedPlatform(browser);
             webDriver = new SafariDriver();
 
-        } else if (IPHONE.equals(browser)) {
-			try {
-				webDriver = new IPhoneDriver();
-			} catch (Exception e) {
-				e.printStackTrace();
-			}
+    } else if (IPHONE.equals(browser)) {
+      webDriver = new RemoteWebDriver(DesiredCapabilities.iphone());
+      
+    } else if (ANDROID.equals(browser)) {
+      webDriver = new RemoteWebDriver(DesiredCapabilities.android());
 
-		} else if (ANDROID.equals(browser)) {
-			webDriver = new AndroidDriver();
-
-		} else {
+    } else {
 
 			// HTMLunit Check
 			if (username != null && password != null) {

--- a/src/main/resources/archetype-resources/src/test/java/pages/TestBase.java
+++ b/src/main/resources/archetype-resources/src/test/java/pages/TestBase.java
@@ -65,24 +65,23 @@ public class TestBase {
 		}
 	}
 
-//	@AfterMethod
-//	public void setScreenshot(ITestResult result) {
-//		if (!result.isSuccess()) {
-//			try {
-//				WebDriver returned = new Augmenter().augment(webDriver);
-//				if (returned != null) {
-//					File f = ((TakesScreenshot) returned)
-//							.getScreenshotAs(OutputType.FILE);
-//					try {
-//						FileUtils.copyFile(f, new File(SCREENSHOT_FOLDER
-//								+ result.getName() + SCREENSHOT_FORMAT));
-//					} catch (IOException e) {
-//						e.printStackTrace();
-//					}
-//				}
-//			} catch (ScreenshotException se) {
-//				se.printStackTrace();
-//			}
-//		}
-//	}
+  @AfterMethod
+  public void setScreenshot(ITestResult result) {
+    if (!result.isSuccess()) {
+      try {
+        WebDriver returned = new Augmenter().augment(webDriver);
+        if (returned != null) {
+          File f = ((TakesScreenshot) returned).getScreenshotAs(OutputType.FILE);
+          try {
+            FileUtils.copyFile(f,
+                new File(SCREENSHOT_FOLDER + result.getName() + SCREENSHOT_FORMAT));
+          } catch (IOException e) {
+            e.printStackTrace();
+          }
+        }
+      } catch (ScreenshotException se) {
+        se.printStackTrace();
+      }
+    }
+  }
 }


### PR DESCRIPTION
For the project:
- version bumped to 0.3
- set packaging as maven archetype
- bumped archetype version to 2.4
- eliminated build warnings
- updated readme

For the generated code:
- bumped testng to 6.9.6, selenium-java to 2.47.2, operadriver to 1.5
- maven-resources-plugin to 2.7 and maven-compiler-plugin to 3.3
- code generation for Java 1.8 (not that it makes a difference)
- added Selendroid 0.16.0 and Appium java-client 3.2.0 for iPhone,removed deprecated references
- uncommented the useful screenshot function
